### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=RandallR,Willena
 maintainer=Willena
 sentence=This is a library for AT24Cxx EEPROMs.
 paragraph=This is a library for AT24Cxx EEPROMs. Learn more on the github repo.
-category=Memory
+category=Data Storage
 url=https://github.com/Willena/Arduino_AT24Cxx_Library
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Memory' in library AT24Cxx is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format